### PR TITLE
Refactoring

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,45 +16,55 @@ import Token from 'markdown-it/lib/token'
 interface TaskListsOptions {
   enabled: boolean
   label: boolean
-  labelAfter: boolean
   lineNumber: boolean
 }
 
+const checkboxRegex = /^ *\[([ x])\] /i
+
 export default function markdownItTaskLists (
   md: MarkdownIt,
-  options: TaskListsOptions = { enabled: false, label: false, labelAfter: false, lineNumber: false }
+  options: TaskListsOptions = { enabled: false, label: false, lineNumber: false }
 ): void {
-  md.core.ruler.after('inline', 'github-task-lists', function (state: StateCore): boolean {
-    const allTokens = state.tokens
-    for (let i = 2; i < allTokens.length; i++) {
-      if (!isTodoItem(allTokens, i)) {
-        continue
-      }
+  md.core.ruler.after('inline', 'github-task-lists', (state) => processToken(state, options))
+  md.renderer.rules.taskListItemCheckbox = (tokens, idx) => {
+    const token = tokens[0]
+    const checkedAttribute = token.attrGet("checked") ? 'checked=""' : ''
+    const disabledAttribute = token.attrGet("disabled") ? 'disabled=""':''
+    const id = token.attrGet("id")
+    const line = token.attrGet("line")
+    const idAttribute = `id="${id}"`
+    const dataLineAttribute = line ? `data-line="${line}"`:''
 
-      todoify(allTokens[i], options)
-      setTokenAttribute(allTokens[i - 2], 'class', `task-list-item ${options.enabled ? ' enabled' : ''}`)
+    return `<input class="task-list-item-checkbox" type="checkbox" ${checkedAttribute} ${disabledAttribute} ${dataLineAttribute} ${idAttribute}">`
+  }
 
-      const parentToken = findParentToken(allTokens, i - 2)
-      if (parentToken) {
-        setTokenAttribute(parentToken, 'class', 'contains-task-list')
-      }
-    }
-    return false
-  })
+  md.renderer.rules.taskListItemLabel_close = () => {
+      return '</label>'
+  }
+
+  md.renderer.rules.taskListItemLabel_open = (tokens) => {
+    const token = tokens[0]
+    const id = token.attrGet('id')
+    return `<label for="${id}">`;
+  }
 }
 
-function setTokenAttribute (token: Token, name: string, value: string) {
-  const index = token.attrIndex(name)
-  const attr: [string, string] = [name, value]
-
-  if (index < 0) {
-    token.attrPush(attr)
-  } else {
-    if (token.attrs == null) {
-      token.attrs = []
+function processToken(state: StateCore, options: TaskListsOptions): boolean {
+  const allTokens = state.tokens
+  for (let i = 2; i < allTokens.length; i++) {
+    if (!isTodoItem(allTokens, i)) {
+      continue
     }
-    token.attrs[index] = attr
+
+    todoify(allTokens[i], options)
+    allTokens[i - 2].attrJoin('class', `task-list-item ${options.enabled ? ' enabled' : ''}`)
+
+    const parentToken = findParentToken(allTokens, i - 2)
+    if (parentToken) {
+      parentToken.attrJoin('class', 'contains-task-list')
+    }
   }
+  return false
 }
 
 function findParentToken (tokens: Token[], index: number): Token|undefined {
@@ -74,74 +84,71 @@ function isTodoItem (tokens: Token[], index: number): boolean {
     startsWithTodoMarkdown(tokens[index])
 }
 
-function todoify (token: Token, options: TaskListsOptions) {
-  if (token.children == null) return
-  token.children.unshift(makeCheckbox(token, options))
-  token.children[1].content = token.children[1].content.slice(3)
-  token.content = token.content.slice(3)
+function todoify (token: Token, options: TaskListsOptions): void {
+  if (token.children == null) {
+    return
+  }
+
+  const id = generateIdForToken(token);
+
+  token.children.splice(0, 0, createCheckboxToken(token, options, id))
+  token.children[1].content = token.children[1].content.replace(checkboxRegex, '');
 
   if (options.label) {
-    if (options.labelAfter) {
-      token.children.pop()
-
-      // Use large random number as id property of the checkbox.
-      const id = `task-item-${Math.ceil(Math.random() * (10000 * 1000) - 1000)}`
-      token.children[0].content = token.children[0].content.slice(0, -1) + ' id="' + id + '">'
-      token.children.push(afterLabel(token.content, id))
-    } else {
-      token.children.unshift(beginLabel())
-      token.children.push(endLabel())
-    }
+    token.children.splice(1, 0, createLabelBeginToken(id))
+    token.children.push(createLabelEndToken())
   }
 }
 
-function makeCheckbox (token: Token, options: TaskListsOptions) {
-  const checkbox = new Token('html_inline', '', 0)
-  const disabledAttr = !options.enabled ? ' disabled="" ' : ''
-  const dataLine = options.lineNumber ? (token.map ? `data-line="${token.map[0]}"` : 'data-line=""') : ''
-
-  if (token.content.indexOf('[ ] ') === 0) {
-    checkbox.content = `<input class="task-list-item-checkbox" ${disabledAttr} type="checkbox" ${dataLine}">`
-  } else if (token.content.indexOf('[x] ') === 0 || token.content.indexOf('[X] ') === 0) {
-    checkbox.content = `<input class="task-list-item-checkbox" checked="" ${disabledAttr} type="checkbox" ${dataLine}>`
+function generateIdForToken(token: Token):string {
+  if (token.map) {
+    return `task-item-${token.map[0]}`
+  } else {
+    return `task-item-${Math.ceil(Math.random() * (10000 * 1000) - 1000)}`
   }
+}
+
+function createCheckboxToken (token: Token, options: TaskListsOptions, id: string): Token{
+  const checkbox = new Token('taskListItemCheckbox', '', 0)
+  if (!options.enabled) {
+    checkbox.attrSet("disabled", 'true')
+  }
+  if (token.map) {
+    checkbox.attrSet("line", token.map[0].toString())
+  }
+  checkbox.attrSet("id", id);
+
+  const checkboxRegexResult = checkboxRegex.exec(token.content)
+  const isChecked = !!checkboxRegexResult && checkboxRegexResult[1].toLowerCase() === 'x'
+  if (isChecked) {
+    checkbox.attrSet("checked", 'true')
+  }
+
   return checkbox
 }
 
-// these next two functions are kind of hacky; probably should really be a
-// true block-level token with .tag=='label'
-function beginLabel () {
-  const token = new Token('html_inline', '', 0)
-  token.content = '<label>'
-  return token
+function createLabelBeginToken(id: string): Token {
+  const labelBeginToken = new Token('taskListItemLabel_open', '', 1)
+  labelBeginToken.attrSet('id', id)
+  return labelBeginToken
 }
 
-function endLabel () {
-  const token = new Token('html_inline', '', 0)
-  token.content = '</label>'
-  return token
+function createLabelEndToken(): Token {
+  return new Token('taskListItemLabel_close', '', -1)
 }
 
-function afterLabel (content: string, id: string) {
-  const token = new Token('html_inline', '', 0)
-  token.content = `<label class="task-list-item-label" for="${id}">${content}</label>`
-  token.attrs = [['for', 'id']]
-  return token
-}
-
-function isInline (token: Token) {
+function isInline (token: Token): boolean {
   return token.type === 'inline'
 }
 
-function isParagraph (token: Token) {
+function isParagraph (token: Token): boolean {
   return token.type === 'paragraph_open'
 }
 
-function isListItem (token: Token) {
+function isListItem (token: Token): boolean {
   return token.type === 'list_item_open'
 }
 
-function startsWithTodoMarkdown (token: Token) {
-  // leading whitespace in a list item is already trimmed off by markdown-it
-  return token.content.indexOf('[ ] ') === 0 || token.content.indexOf('[x] ') === 0 || token.content.indexOf('[X] ') === 0
+function startsWithTodoMarkdown (token: Token): boolean {
+  return checkboxRegex.test(token.content)
 }

--- a/index.ts
+++ b/index.ts
@@ -33,7 +33,7 @@ export default function markdownItTaskLists (
     const id = token.attrGet("id")
     const line = token.attrGet("line")
     const idAttribute = `id="${id}"`
-    const dataLineAttribute = line ? `data-line="${line}"` : ''
+    const dataLineAttribute = line && options.lineNumber ? `data-line="${line}"` : ''
 
     return `<input class="task-list-item-checkbox" type="checkbox" ${checkedAttribute} ${disabledAttribute} ${dataLineAttribute} ${idAttribute}">`
   }
@@ -91,7 +91,7 @@ function todoify (token: Token, options: TaskListsOptions): void {
 
   const id = generateIdForToken(token)
 
-  token.children.splice(0, 0, createCheckboxToken(token, options, id))
+  token.children.splice(0, 0, createCheckboxToken(token, options.enabled, id))
   token.children[1].content = token.children[1].content.replace(checkboxRegex, '')
 
   if (options.label) {
@@ -108,14 +108,15 @@ function generateIdForToken (token: Token): string {
   }
 }
 
-function createCheckboxToken (token: Token, options: TaskListsOptions, id: string): Token {
+function createCheckboxToken (token: Token, enabled: boolean, id: string): Token {
   const checkbox = new Token('taskListItemCheckbox', '', 0)
-  if (!options.enabled) {
+  if (!enabled) {
     checkbox.attrSet("disabled", 'true')
   }
   if (token.map) {
     checkbox.attrSet("line", token.map[0].toString())
   }
+
   checkbox.attrSet("id", id)
 
   const checkboxRegexResult = checkboxRegex.exec(token.content)

--- a/index.ts
+++ b/index.ts
@@ -26,30 +26,30 @@ export default function markdownItTaskLists (
   options: TaskListsOptions = { enabled: false, label: false, lineNumber: false }
 ): void {
   md.core.ruler.after('inline', 'github-task-lists', (state) => processToken(state, options))
-  md.renderer.rules.taskListItemCheckbox = (tokens, idx) => {
+  md.renderer.rules.taskListItemCheckbox = (tokens) => {
     const token = tokens[0]
     const checkedAttribute = token.attrGet("checked") ? 'checked=""' : ''
-    const disabledAttribute = token.attrGet("disabled") ? 'disabled=""':''
+    const disabledAttribute = token.attrGet("disabled") ? 'disabled=""' : ''
     const id = token.attrGet("id")
     const line = token.attrGet("line")
     const idAttribute = `id="${id}"`
-    const dataLineAttribute = line ? `data-line="${line}"`:''
+    const dataLineAttribute = line ? `data-line="${line}"` : ''
 
     return `<input class="task-list-item-checkbox" type="checkbox" ${checkedAttribute} ${disabledAttribute} ${dataLineAttribute} ${idAttribute}">`
   }
 
   md.renderer.rules.taskListItemLabel_close = () => {
-      return '</label>'
+    return '</label>'
   }
 
   md.renderer.rules.taskListItemLabel_open = (tokens) => {
     const token = tokens[0]
     const id = token.attrGet('id')
-    return `<label for="${id}">`;
+    return `<label for="${id}">`
   }
 }
 
-function processToken(state: StateCore, options: TaskListsOptions): boolean {
+function processToken (state: StateCore, options: TaskListsOptions): boolean {
   const allTokens = state.tokens
   for (let i = 2; i < allTokens.length; i++) {
     if (!isTodoItem(allTokens, i)) {
@@ -67,7 +67,7 @@ function processToken(state: StateCore, options: TaskListsOptions): boolean {
   return false
 }
 
-function findParentToken (tokens: Token[], index: number): Token|undefined {
+function findParentToken (tokens: Token[], index: number): Token | undefined {
   const targetLevel = tokens[index].level - 1
   for (let currentTokenIndex = index - 1; currentTokenIndex >= 0; currentTokenIndex--) {
     if (tokens[currentTokenIndex].level === targetLevel) {
@@ -89,10 +89,10 @@ function todoify (token: Token, options: TaskListsOptions): void {
     return
   }
 
-  const id = generateIdForToken(token);
+  const id = generateIdForToken(token)
 
   token.children.splice(0, 0, createCheckboxToken(token, options, id))
-  token.children[1].content = token.children[1].content.replace(checkboxRegex, '');
+  token.children[1].content = token.children[1].content.replace(checkboxRegex, '')
 
   if (options.label) {
     token.children.splice(1, 0, createLabelBeginToken(id))
@@ -100,7 +100,7 @@ function todoify (token: Token, options: TaskListsOptions): void {
   }
 }
 
-function generateIdForToken(token: Token):string {
+function generateIdForToken (token: Token): string {
   if (token.map) {
     return `task-item-${token.map[0]}`
   } else {
@@ -108,7 +108,7 @@ function generateIdForToken(token: Token):string {
   }
 }
 
-function createCheckboxToken (token: Token, options: TaskListsOptions, id: string): Token{
+function createCheckboxToken (token: Token, options: TaskListsOptions, id: string): Token {
   const checkbox = new Token('taskListItemCheckbox', '', 0)
   if (!options.enabled) {
     checkbox.attrSet("disabled", 'true')
@@ -116,7 +116,7 @@ function createCheckboxToken (token: Token, options: TaskListsOptions, id: strin
   if (token.map) {
     checkbox.attrSet("line", token.map[0].toString())
   }
-  checkbox.attrSet("id", id);
+  checkbox.attrSet("id", id)
 
   const checkboxRegexResult = checkboxRegex.exec(token.content)
   const isChecked = !!checkboxRegexResult && checkboxRegexResult[1].toLowerCase() === 'x'
@@ -127,13 +127,13 @@ function createCheckboxToken (token: Token, options: TaskListsOptions, id: strin
   return checkbox
 }
 
-function createLabelBeginToken(id: string): Token {
+function createLabelBeginToken (id: string): Token {
   const labelBeginToken = new Token('taskListItemLabel_open', '', 1)
   labelBeginToken.attrSet('id', id)
   return labelBeginToken
 }
 
-function createLabelEndToken(): Token {
+function createLabelEndToken (): Token {
   return new Token('taskListItemLabel_close', '', -1)
 }
 

--- a/package.json
+++ b/package.json
@@ -34,10 +34,8 @@
       "js"
     ]
   },
-  "dependencies": {
-    "markdown-it": "^12.0.0"
-  },
   "devDependencies": {
+    "markdown-it": "^12.0.0",
     "@types/markdown-it": "^12.0.0",
     "@types/jest": "26.0.19",
     "@types/punycode": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hedgedoc/markdown-it-task-lists",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "description": "A markdown-it plugin to create GitHub-style task lists",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -117,7 +117,7 @@ describe('markdown-it-task-lists', () => {
     it.each(Array.from(fixtures))('%s: wraps and enables items', (name, mdDoc) => {
       const dom = domParser.parseFromString(enabledLabeledParser.render(mdDoc), 'text/html')
       expect(dom.querySelectorAll(
-        '.task-list-item > label > input[type=checkbox].task-list-item-checkbox:not([disabled])'
+        '.task-list-item > input[type=checkbox].task-list-item-checkbox:not([disabled]) + label'
       ).length).toBeGreaterThan(0)
     })
   })


### PR DESCRIPTION
### Description
This PR does a general refactoring of the code. It
  - Fixes the rendering of labels
  - Fixes the rendering of content after the checkbox
  - Increases the version to 1.0.0
  - Removes the "afterLabel" option, because we don't need it in the react-client
  - Removes the `html_inline` rendering with specific renderings
  - Moves the markdown-it dependency to dev , because it is only needed for tests

### Steps

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/markdown-it-better-task-lists/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
