### PR TITLE
fix: Extra quotes and spaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,21 +28,21 @@ export default function markdownItTaskLists (
   md.core.ruler.after('inline', 'github-task-lists', (state) => processToken(state, options))
   md.renderer.rules.taskListItemCheckbox = (tokens) => {
     const token = tokens[0]
-    const checkedAttribute = token.attrGet("checked") ? 'checked=""' : ''
-    const disabledAttribute = token.attrGet("disabled") ? 'disabled=""' : ''
-    const id = token.attrGet("id")
-    const line = token.attrGet("line")
-    const idAttribute = `id="${id}"`
-    const dataLineAttribute = line && options.lineNumber ? `data-line="${line}"` : ''
+    const checkedAttribute = token.attrGet('checked') ? 'checked="" ' : ''
+    const disabledAttribute = token.attrGet('disabled') ? 'disabled="" ' : ''
+    const id = token.attrGet('id')
+    const line = token.attrGet('line')
+    const idAttribute = `id="${id}" `
+    const dataLineAttribute = line && options.lineNumber ? `data-line="${line}" ` : ''
 
-    return `<input class="task-list-item-checkbox" type="checkbox" ${checkedAttribute} ${disabledAttribute} ${dataLineAttribute} ${idAttribute}">`
+    return `<input class="task-list-item-checkbox" type="checkbox" ${checkedAttribute}${disabledAttribute}${dataLineAttribute}${idAttribute}/>`
   }
 
   md.renderer.rules.taskListItemLabel_close = () => {
     return '</label>'
   }
 
-  md.renderer.rules.taskListItemLabel_open = (tokens) => {
+  md.renderer.rules.taskListItemLabel_open = (tokens: Token[]) => {
     const token = tokens[0]
     const id = token.attrGet('id')
     return `<label for="${id}">`
@@ -111,18 +111,18 @@ function generateIdForToken (token: Token): string {
 function createCheckboxToken (token: Token, enabled: boolean, id: string): Token {
   const checkbox = new Token('taskListItemCheckbox', '', 0)
   if (!enabled) {
-    checkbox.attrSet("disabled", 'true')
+    checkbox.attrSet('disabled', 'true')
   }
   if (token.map) {
-    checkbox.attrSet("line", token.map[0].toString())
+    checkbox.attrSet('line', token.map[0].toString())
   }
 
-  checkbox.attrSet("id", id)
+  checkbox.attrSet('id', id)
 
   const checkboxRegexResult = checkboxRegex.exec(token.content)
   const isChecked = !!checkboxRegexResult && checkboxRegexResult[1].toLowerCase() === 'x'
   if (isChecked) {
-    checkbox.attrSet("checked", 'true')
+    checkbox.attrSet('checked', 'true')
   }
 
   return checkbox

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -67,6 +67,11 @@ describe('markdown-it-task-lists', () => {
     expect(actuallyChecked).toBe(shouldBeChecked)
   })
 
+  it.only('input renders correctly', () => {
+    const strs = rendered.get('bullet')?.match(/<input\s([\w\-]+=\"[\w\s\-]{0,}"\s){0,}\/>/gm)
+    expect(strs?.length).toBe(4)
+  })
+
   describe('when option enabled is unset', () => {
     const dom = parsed.get('bullet')!!
     it('number of not disabled inputs is 0', () => {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2020 The HedgeDoc developers (see AUTHORS file)

SPDX-License-Identifier: CC-BY-SA-4.0
-->

### Description

I tried to use the plugin in `Slidev`. rendering result can't pass syntax checking.

fix: input element renders 2 quotes at the end.
chore: space count will be more reasonable.
chore: change quotes from double to single when they are in JS.

### Related Issue(s)

NaN
