### PR TITLE
Checkboxes may contain any whitespace instead of only a space

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ interface TaskListsOptions {
   lineNumber: boolean
 }
 
-const checkboxRegex = /^ *\[([ x])] /i
+const checkboxRegex = /^ *\[([\sx])] /i
 
 export default function markdownItTaskLists(
   md: MarkdownIt,


### PR DESCRIPTION
### Description
As of https://github.github.com/gfm/#task-list-item-marker
> A task list item marker consists of an optional number of spaces,
> a left bracket (`[`), either a **whitespace** character or the letter x [...],
> and then a right bracket (`]`).

So this modifies the regex to also allow other whitespaces.
You can test it here on github, github also allows `\t` and even `\n`.

### Steps
- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/markdown-it-better-task-lists/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
