### PR TITLE
Use official jest types

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@jest/types": "28.1.3",
     "@mrdrogdrog/optional": "0.1.2",
-    "@types/jest": "28.1.4",
     "@types/jsdom": "16.2.14",
     "@types/markdown-it": "12.2.3",
     "@types/node": "18.0.0",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -11,6 +11,7 @@ import { JSDOM } from 'jsdom'
 import { Fixtures, loadFixtures } from './test-utils/fixtures/load-fixtures'
 
 const DOMParser = new JSDOM().window.DOMParser
+import { describe, expect, it } from '@jest/globals'
 
 describe('markdown-it-task-lists', () => {
   const taskListMarkdownParser = new MarkdownIt().use(taskLists)

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,8 +417,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hedgedoc/markdown-it-task-lists@workspace:."
   dependencies:
+    "@jest/types": 28.1.3
     "@mrdrogdrog/optional": 0.1.2
-    "@types/jest": 28.1.4
     "@types/jsdom": 16.2.14
     "@types/markdown-it": 12.2.3
     "@types/node": 18.0.0
@@ -696,7 +696,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/types@npm:^28.1.1, @jest/types@npm:^28.1.3":
+"@jest/types@npm:28.1.3, @jest/types@npm:^28.1.1, @jest/types@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/types@npm:28.1.3"
   dependencies:
@@ -920,16 +920,6 @@ __metadata:
   dependencies:
     "@types/istanbul-lib-report": "*"
   checksum: f1ad54bc68f37f60b30c7915886b92f86b847033e597f9b34f2415acdbe5ed742fa559a0a40050d74cdba3b6a63c342cac1f3a64dba5b68b66a6941f4abd7903
-  languageName: node
-  linkType: hard
-
-"@types/jest@npm:28.1.4":
-  version: 28.1.4
-  resolution: "@types/jest@npm:28.1.4"
-  dependencies:
-    jest-matcher-utils: ^28.0.0
-    pretty-format: ^28.0.0
-  checksum: 97e22c600397bb4f30e39b595f8285ae92e4eb29a1ef6d1689749e4a4da683d88ecfe717b64492f6adc4c17c1c989520c3546f938c84a7d435c6ac3acf1a2bdc
   languageName: node
   linkType: hard
 
@@ -2990,7 +2980,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-matcher-utils@npm:^28.0.0, jest-matcher-utils@npm:^28.1.3":
+"jest-matcher-utils@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-matcher-utils@npm:28.1.3"
   dependencies:
@@ -3974,7 +3964,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^28.0.0, pretty-format@npm:^28.1.3":
+"pretty-format@npm:^28.1.3":
   version: 28.1.3
   resolution: "pretty-format@npm:28.1.3"
   dependencies:


### PR DESCRIPTION
### Description
This PR swaps `@types/jest` with `jest/type` as it is the official type package.

### Steps

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/markdown-it-better-task-lists/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
